### PR TITLE
Fix private DNS zone conflict in systemtest_auto environment

### DIFF
--- a/5.spoke-network/app-parameters/dev.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/dev.parameters.bicepparam
@@ -41,7 +41,7 @@ param parSpokeNetworks = [
     rgSharedServices: 'rg-rsp-sharedservices-spoke-dev-uks'
     rgStorage: 'rg-rsp-storage-spoke-dev-uks'
     deployWebAppSlot: false
-    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
+    skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     IDGENV: 'dev'
     appInsightsConnectionString: 'InstrumentationKey=1925d527-9a3a-4439-9bf5-375666529422;IngestionEndpoint=https://uksouth-1.in.applicationinsights.azure.com/;LiveEndpoint=https://uksouth.livediagnostics.monitor.azure.com/;ApplicationId=0dd21ec7-c4a7-40da-8c7e-75f31d979301'
   }

--- a/5.spoke-network/app-parameters/dev.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/dev.parameters.bicepparam
@@ -41,6 +41,7 @@ param parSpokeNetworks = [
     rgSharedServices: 'rg-rsp-sharedservices-spoke-dev-uks'
     rgStorage: 'rg-rsp-storage-spoke-dev-uks'
     deployWebAppSlot: false
+    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     IDGENV: 'dev'
     appInsightsConnectionString: 'InstrumentationKey=1925d527-9a3a-4439-9bf5-375666529422;IngestionEndpoint=https://uksouth-1.in.applicationinsights.azure.com/;LiveEndpoint=https://uksouth.livediagnostics.monitor.azure.com/;ApplicationId=0dd21ec7-c4a7-40da-8c7e-75f31d979301'
   }

--- a/5.spoke-network/app-parameters/pre_prod.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/pre_prod.parameters.bicepparam
@@ -15,7 +15,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: true
     devBoxPeering: false
-    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
+    skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-preprod-uks'
     vnet: 'vnet-rsp-networking-preprod-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-preprod-uks'

--- a/5.spoke-network/app-parameters/pre_prod.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/pre_prod.parameters.bicepparam
@@ -15,6 +15,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: true
     devBoxPeering: false
+    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-preprod-uks'
     vnet: 'vnet-rsp-networking-preprod-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-preprod-uks'

--- a/5.spoke-network/app-parameters/production.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/production.parameters.bicepparam
@@ -15,6 +15,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: true
     devBoxPeering: false
+    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-prod-uks'
     vnet: 'vnet-rsp-networking-prod-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-prod-uks'

--- a/5.spoke-network/app-parameters/production.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/production.parameters.bicepparam
@@ -15,7 +15,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: true
     devBoxPeering: false
-    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
+    skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-prod-uks'
     vnet: 'vnet-rsp-networking-prod-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-prod-uks'

--- a/5.spoke-network/app-parameters/systemtest_auto.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/systemtest_auto.parameters.bicepparam
@@ -41,6 +41,7 @@ param parSpokeNetworks = [
     rgSharedServices: 'rg-rsp-sharedservices-spoke-systemtestauto-uks'
     rgStorage: 'rg-rsp-storage-spoke-systemtestauto-uks'
     deployWebAppSlot: false
+    skipPrivateDnsZoneCreation: true  // Skip DNS zone creation since it already exists
     IDGENV: 'test'
     appInsightsConnectionString: 'InstrumentationKey=225c2ec1-bb7d-4c33-9d5f-cb89c117f2d6;IngestionEndpoint=https://uksouth-1.in.applicationinsights.azure.com/;LiveEndpoint=https://uksouth.livediagnostics.monitor.azure.com/;ApplicationId=3dc21d1c-0655-44cc-8ad3-cb4eab8c8c67'
   }

--- a/5.spoke-network/app-parameters/systemtest_manual.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/systemtest_manual.parameters.bicepparam
@@ -35,6 +35,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: false
     devBoxPeering: false
+    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-systemtest-uks'
     vnet: 'vnet-rsp-networking-manualtest-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-systemtest-uks'

--- a/5.spoke-network/app-parameters/systemtest_manual.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/systemtest_manual.parameters.bicepparam
@@ -35,7 +35,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: false
     devBoxPeering: false
-    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
+    skipPrivateDnsZoneCreation: true  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-systemtest-uks'
     vnet: 'vnet-rsp-networking-manualtest-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-systemtest-uks'

--- a/5.spoke-network/app-parameters/uat.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/uat.parameters.bicepparam
@@ -15,6 +15,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: true
     devBoxPeering: false
+    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-uat-uks'
     vnet: 'vnet-rsp-networking-uat-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-uat-uks'

--- a/5.spoke-network/app-parameters/uat.parameters.bicepparam
+++ b/5.spoke-network/app-parameters/uat.parameters.bicepparam
@@ -15,7 +15,7 @@ param parSpokeNetworks = [
     deploy: false
     configurePrivateDNS: true
     devBoxPeering: false
-    // skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
+    skipPrivateDnsZoneCreation: false  // Set to true after initial deployment to avoid DNS zone conflicts
     rgNetworking: 'rg-rsp-networking-spoke-uat-uks'
     vnet: 'vnet-rsp-networking-uat-uks-spoke'
     rgapplications: 'rg-rsp-applications-spoke-uat-uks'

--- a/5.spoke-network/main.application.bicep
+++ b/5.spoke-network/main.application.bicep
@@ -243,6 +243,7 @@ module containerAppsEnvironment 'modules/04-container-apps-environment/deploy.ac
       logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
       deployZoneRedundantResources: parSpokeNetworks[i].zoneRedundancy
       //privateDNSEnabled: parSpokeNetworks[i].configurePrivateDNS
+      skipPrivateDnsZoneCreation: parSpokeNetworks[i].skipPrivateDnsZoneCreation 
       resourcesNames: applicationServicesNaming[i].outputs.resourcesNames
       networkRG: parSpokeNetworks[i].rgNetworking
     }

--- a/5.spoke-network/modules/04-container-apps-environment/deploy.aca-environment.bicep
+++ b/5.spoke-network/modules/04-container-apps-environment/deploy.aca-environment.bicep
@@ -33,6 +33,9 @@ param deployZoneRedundantResources bool = true
 // @description('The name of the hub virtual network.')
 // param hubVNetName string = ''
 
+@description('Optional, default value is false. If true, skip creating private DNS zone to avoid conflicts with existing zones. NOTE: Set this to true after the initial deployment since Container Apps creates its own private DNS zone during the first deployment.')
+param skipPrivateDnsZoneCreation bool = false
+
 param resourcesNames object
 param networkRG string
 
@@ -93,7 +96,7 @@ module containerAppsEnvironment '../../../shared/bicep/aca-environment.bicep' = 
 }
 
 @description('The Private DNS zone containing the ACA load balancer IP')
-module containerAppsEnvironmentPrivateDnsZone '../../../shared/bicep/network/private-dns-zone.bicep' = {
+module containerAppsEnvironmentPrivateDnsZone '../../../shared/bicep/network/private-dns-zone.bicep' = if (!skipPrivateDnsZoneCreation) {
   scope: resourceGroup(networkRG)
   name: 'containerAppsEnvironmentPrivateDnsZone-${uniqueString(resourceGroup().id)}'
   params: {


### PR DESCRIPTION
## Summary
- Added skipPrivateDnsZoneCreation parameter to control DNS zone creation
- Set parameter to true for systemtest_auto environment to fix deployment error
- Added commented parameter to other environments for easy configuration
- Updated documentation to note when to use the parameter

