### PR TITLE
RSP-3876: Add storage account parameters for App Configuration module

### DIFF
--- a/.azuredevops/pipelines/application-deployment.yml
+++ b/.azuredevops/pipelines/application-deployment.yml
@@ -145,7 +145,7 @@ jobs:
                            parAdminLogin=$(rspsqladminloginname) parSqlAdminPhrase=$(rspsqladminphrase) \
                            parClientID=$(clientID) parClientSecret=$(clientSecret) \
                            logAnalyticsWorkspaceId=$(logAnalyticsWorkspaceId) parDevOpsPublicIPAddress=$(devOpsPublicIP) \
-                           parStorageAccountName=$(documentBlobstorageAccountName) parStorageAccountKey=$(documentBlobstorageAccountKey)
+                           parStorageAccountName=$(documentBlobstorageAccountName) parStorageAccountKey=$(documentBlobstorageAccountKey) \
                            --deny-settings-mode none --action-on-unmanage deleteResources --yes)
             echo $output | jq .
             appResourceGroup=$(echo $output | jq -r '.properties.outputs.appResourceGroupName.value')


### PR DESCRIPTION
Added a missing `\` when adding a new parameter to the CLI